### PR TITLE
Feat: Improved cache handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,30 +109,6 @@ Default: `true`
 
 > Ignore the optimized output if it is larger than the original file.
 
-### cache
-
-Type: `boolean`<br>
-Default: `true`
-
-> Skip optimizing the input if it did not change since the last run.
-
-### cacheDir
-
-Type: `string`<br>
-Default: `<packageRoot>/node_modules/.cache/vite-plugin-imagemin/<packageName>/`
-
-> Choose the directory to use for caching.
-> - Relative paths will be relative to the Vite project's **root** directory.
-> - Absolute paths will be use as-is.
-> - Absent/non-string value will use the default location.
-
-### clearCache
-
-Type: `boolean`<br>
-Default: `false`
-
-> Clears the cache folder before processing.
-
 ### makeAvif / makeWebp
 
 Type: `object`<br>
@@ -163,6 +139,40 @@ Default: `'optimized'`
 > - larger than the optimized image (`'optimized'`)
 > - it is not the smallest version of the image (`'smallest'`)
 > - never skip (`false`)
+
+### cache
+
+Type: `boolean`<br>
+Default: `true`
+
+> Skip optimizing the input if it did not change since the last run.
+
+### cacheDir
+
+Type: `string`<br>
+Default: `<packageRoot>/node_modules/.cache/vite-plugin-imagemin/<packageName>/`
+
+> Choose the directory to use for caching.
+> - Relative paths will be relative to the Vite project's **root** directory.
+> - Absolute paths will be use as-is.
+> - Absent/non-string value will use the default location.
+
+### cacheKey
+
+Type: `string`<br>
+Default: ``
+
+> Optional string to distinguish build configs and their caches.
+>
+> The cache identifier is a hash of most used options including this key.
+> Note: Because options like `formatFilePath` and `plugins` cannot be stringified, they will have little or no influence on the hash key and its uniqueness.
+
+### clearCache
+
+Type: `boolean`<br>
+Default: `false`
+
+> Clears the cache folder before processing.
 
 ### root
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 - Can create Avif versions of supported images (jpg/png).
 - Skips optimized version if output is larger than original.
 - Skips Avif/WebP version if output is larger than original, optimized version or smallest version of an image.
-- Uses cache to skip processing of unchanged files
+- Uses optional cache by default to skip processing of unchanged files
 
 ## Install
 
@@ -115,6 +115,23 @@ Type: `boolean`<br>
 Default: `true`
 
 > Skip optimizing the input if it did not change since the last run.
+
+### cacheDir
+
+Type: `string`<br>
+Default: `<packageRoot>/node_modules/.cache/vite-plugin-imagemin/<packageName>/`
+
+> Choose the directory to use for caching.
+> - Relative paths will be relative to the Vite project's **root** directory.
+> - Absolute paths will be use as-is.
+> - Absent/non-string value will use the default location.
+
+### clearCache
+
+Type: `boolean`<br>
+Default: `false`
+
+> Clears the cache folder before processing.
 
 ### makeAvif / makeWebp
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -61,7 +61,6 @@
     "node": ">=16.0.0"
   },
   "dependencies": {
-    "@file-cache/core": "^1.1.4",
     "chalk": "^5.2.0",
     "fast-glob": "^3.2.12",
     "fs-extra": "^11.1.1",

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -93,7 +93,7 @@ async function checkAndUpdate({
   buffer,
   restoreTo,
 }: {
-  fileName?: string
+  fileName: string
   directory?: string
   stats?: Omit<CacheValue, 'hash'>
   buffer?: Buffer
@@ -104,6 +104,12 @@ async function checkAndUpdate({
   error?: Error
 }> {
   if (cacheEnabled) {
+    if (!fileName) {
+      return {
+        error: new Error('Missing filename'),
+      }
+    }
+
     const filePath = (directory ?? cacheDir) + fileName
 
     if (!buffer) {
@@ -172,17 +178,23 @@ export const FileCache = {
 
   update: async ({
     fileName,
+    buffer,
     directory,
     stats,
-    buffer,
   }: {
-    fileName?: string
+    fileName: string
+    buffer: Buffer
     directory?: string
     stats?: Omit<CacheValue, 'hash'>
-    buffer: Buffer
   }) => {
     if (!cacheEnabled) {
       return false
+    }
+
+    if (!fileName) {
+      return {
+        error: new Error('Missing filename'),
+      }
     }
 
     if (!buffer) {

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -1,7 +1,7 @@
-import crypto, { BinaryLike } from 'crypto'
-import { copyFileSync, existsSync } from 'node:fs'
+import crypto, { BinaryLike } from 'node:crypto'
+import { existsSync } from 'node:fs'
 import { copyFile, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
-import path from 'node:path'
+import { isAbsolute, resolve } from 'node:path'
 import { normalizePath } from 'vite'
 
 import {
@@ -11,39 +11,71 @@ import {
   smartEnsureDirs,
 } from './utils'
 
-import type { ResolvedConfigOptions, StackItem } from './typings'
-
-type CacheValue = {
-  hash: string
-}
+import type { CacheValue, ResolvedConfigOptions, StackItem } from './typings'
 
 let cacheEnabled = false
 let cacheDir = ''
+let cacheKey = ''
 let cacheFile = ''
 let fileCacheMap = new Map<string, CacheValue>()
 let entryMap = new Map<string, CacheValue>()
 
-async function initCacheDir(rootDir: string, _cacheDir?: string) {
-  // Note: Only cacheDir has a trailing slash.
-  if (isString(_cacheDir)) {
-    cacheDir =
-      normalizePath(
-        path.isAbsolute(_cacheDir)
-          ? _cacheDir
-          : path.resolve(rootDir, _cacheDir),
-      ) + '/'
+function md5(buffer: BinaryLike): string {
+  return crypto.createHash('md5').update(buffer).digest('hex')
+}
+
+export function createCacheKey(options: ResolvedConfigOptions) {
+  return md5(
+    Object.entries(options)
+      .filter(
+        ([k]) =>
+          // Ignore these options, since they don't influence the files' content.
+          ![
+            'cache',
+            'clearCache',
+            'logByteDivider',
+            'logger',
+            'verbose',
+          ].includes(k),
+      )
+      .sort(([ka], [kb]) => ka.localeCompare(kb))
+      .map(([k, v], i) => `${i}_${k}_${v}`)
+      .join('|'),
+  )
+}
+
+async function initCacheDir(rootDir: string, options: ResolvedConfigOptions) {
+  cacheKey = createCacheKey(options)
+
+  const packageDir = normalizePath(getPackageDirectory())
+  const packageName = getPackageName(packageDir)
+
+  if (isString(options.cacheDir)) {
+    cacheDir = normalizePath(
+      isAbsolute(options.cacheDir)
+        ? options.cacheDir
+        : resolve(rootDir, options.cacheDir),
+    )
   } else {
-    const packageDir = normalizePath(getPackageDirectory())
-    cacheDir = `${packageDir}/node_modules/.cache/vite-plugin-imagemin/${getPackageName(
-      packageDir,
-    )}/`
+    cacheDir = `${packageDir}/node_modules/.cache/vite-plugin-imagemin`
+  }
+
+  // cacheDir = cacheDir + `/${packageName}/${cacheKey}/`
+  cacheDir = cacheDir + `/${packageName}/`
+
+  if (options.clearCache) {
+    await rm(cacheDir.slice(0, -1), { recursive: true, force: true })
+  }
+
+  if (!cacheEnabled) {
+    return
   }
 
   await mkdir(cacheDir.slice(0, -1), { recursive: true })
 }
 
 async function initCacheMaps() {
-  cacheFile = path.join(cacheDir, 'contents')
+  cacheFile = `${cacheDir}/contents-${cacheKey}.json`
 
   try {
     const json = JSON.parse(await readFile(cacheFile, 'utf-8'))
@@ -55,31 +87,39 @@ async function initCacheMaps() {
   fileCacheMap = new Map<string, CacheValue>(entryMap)
 }
 
-function md5(buffer: BinaryLike): string {
-  return crypto.createHash('md5').update(buffer).digest('hex')
-}
-
-async function getAndUpdateCacheContent(filePath: string | URL) {
+async function getAndUpdateCacheContent(
+  filePath: string,
+  stats?: Omit<CacheValue, 'hash'>,
+): Promise<{
+  changed?: boolean
+  value?: CacheValue
+  error?: Error
+}> {
+  let hash = ''
   try {
-    const hash = md5(await readFile(filePath))
-    const normalizedFilePath = filePath.toString()
-    const cacheValue = fileCacheMap.get(normalizedFilePath) as
-      | CacheValue
-      | undefined
-    if (cacheValue && cacheValue.hash === hash) {
-      return {
-        changed: false,
-      }
-    }
-    entryMap.set(normalizedFilePath, { hash })
-    return {
-      changed: true,
-    }
+    hash = md5(await readFile(filePath))
   } catch (error) {
     return {
-      changed: false,
       error: error as Error,
     }
+  }
+
+  const cacheValue = fileCacheMap.get(filePath)
+  if (cacheValue && cacheValue.hash === hash) {
+    return {
+      changed: false,
+      value: cacheValue,
+    }
+  }
+
+  entryMap.set(filePath, {
+    hash,
+    oldSize: stats?.oldSize ?? 0,
+    newSize: stats?.newSize ?? 0,
+  })
+
+  return {
+    changed: true,
   }
 }
 
@@ -87,70 +127,89 @@ export const FileCache = {
   init: async (options: ResolvedConfigOptions, rootDir: string) => {
     cacheEnabled = options.cache !== false
 
-    await initCacheDir(rootDir, options.cacheDir)
+    await initCacheDir(rootDir, options)
 
-    // clear cache?
-    if (options.clearCache && cacheDir) {
-      await rm(cacheDir.slice(0, -1), { recursive: true, force: true })
+    if (!cacheEnabled) {
+      return
     }
 
     await initCacheMaps()
   },
 
   prepareDirs: (filePaths: string[]): void => {
-    if (cacheEnabled) {
-      smartEnsureDirs(filePaths.map(file => cacheDir + file))
+    if (!cacheEnabled) {
+      return
     }
+
+    smartEnsureDirs(filePaths.map(file => cacheDir + file))
   },
 
-  check: async (
+  checkAndCopy: async (
     baseDir: string,
     filePathFrom: string,
     fileToStack: StackItem[] = [],
-  ) => {
-    const { changed, error } = await getAndUpdateCacheContent(
+  ): Promise<[boolean, (string | CacheValue)[]]> => {
+    if (!cacheEnabled) {
+      return [false, []]
+    }
+
+    const inputCacheStatus = await getAndUpdateCacheContent(
       baseDir + filePathFrom,
     )
 
     // Check if input file has changed or there was an error
-    if (changed || error) {
-      return false
+    if (inputCacheStatus?.error || inputCacheStatus?.changed) {
+      return [false, []]
     }
 
     // Check if output files are in cache and use them if they haven't changed
     const outputFilesExist = await Promise.allSettled(
-      fileToStack.map(
-        item =>
-          new Promise((resolve, reject) =>
-            getAndUpdateCacheContent(cacheDir + item.toPath)
-              .then(outputFileCache => {
-                if (!outputFileCache.error && !outputFileCache.changed) {
-                  copyFileSync(cacheDir + item.toPath, baseDir + item.toPath)
-                  if (existsSync(baseDir + item.toPath)) {
-                    resolve(true)
-                  }
-                }
-                reject(
-                  outputFileCache.error
-                    ? `Error while checking cache [${outputFileCache.error.message}]`
-                    : 'Could not copy cached files',
-                )
-              })
-              .catch(reject),
-          ),
-      ),
+      fileToStack.map(async item => {
+        const outputCacheStatus = await getAndUpdateCacheContent(
+          cacheDir + item.toPath,
+        )
+
+        if (outputCacheStatus?.error) {
+          return `Cache error [${outputCacheStatus.error.message}]`
+        }
+
+        if (outputCacheStatus?.changed) {
+          return 'File changed'
+        }
+
+        try {
+          await copyFile(cacheDir + item.toPath, baseDir + item.toPath)
+        } catch (error) {
+          return `Could not copy cached file [${(error as Error).message}]`
+        }
+
+        if (!existsSync(baseDir + item.toPath)) {
+          return 'Could not use cached file'
+        }
+
+        return outputCacheStatus.value as CacheValue
+      }),
     )
 
-    return outputFilesExist.every(p => p.status === 'fulfilled')
+    return [
+      true,
+      outputFilesExist.map(p =>
+        p.status === 'fulfilled' ? p.value : p.reason,
+      ),
+    ]
   },
 
-  update: async (baseDir: string, filePathTo: string) => {
+  update: async (
+    baseDir: string,
+    filePathTo: string,
+    stats: Omit<CacheValue, 'hash'>,
+  ) => {
     if (!cacheEnabled) {
       return
     }
 
     await copyFile(baseDir + filePathTo, cacheDir + filePathTo)
-    await getAndUpdateCacheContent(cacheDir + filePathTo)
+    await getAndUpdateCacheContent(cacheDir + filePathTo, stats)
   },
 
   reconcile: async () => {
@@ -164,11 +223,12 @@ export const FileCache = {
         JSON.stringify(Object.fromEntries(entryMap)),
         'utf-8',
       )
-      // reflect the changes in the cacheMap
+
       fileCacheMap = new Map(entryMap)
+
       return true
     } catch (error) {
-      //   console.error('Cache reconcile has failed', error)
+      // console.error('Cache reconcile has failed', error)
       return false
     }
   },

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -1,0 +1,175 @@
+import crypto, { BinaryLike } from 'crypto'
+import { copyFileSync, existsSync } from 'node:fs'
+import { copyFile, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { normalizePath } from 'vite'
+
+import {
+  getPackageDirectory,
+  getPackageName,
+  isString,
+  smartEnsureDirs,
+} from './utils'
+
+import type { ResolvedConfigOptions, StackItem } from './typings'
+
+type CacheValue = {
+  hash: string
+}
+
+let cacheEnabled = false
+let cacheDir = ''
+let cacheFile = ''
+let fileCacheMap = new Map<string, CacheValue>()
+let entryMap = new Map<string, CacheValue>()
+
+async function initCacheDir(rootDir: string, _cacheDir?: string) {
+  // Note: Only cacheDir has a trailing slash.
+  if (isString(_cacheDir)) {
+    cacheDir =
+      normalizePath(
+        path.isAbsolute(_cacheDir)
+          ? _cacheDir
+          : path.resolve(rootDir, _cacheDir),
+      ) + '/'
+  } else {
+    const packageDir = normalizePath(getPackageDirectory())
+    cacheDir = `${packageDir}/node_modules/.cache/vite-plugin-imagemin/${getPackageName(
+      packageDir,
+    )}/`
+  }
+
+  await mkdir(cacheDir.slice(0, -1), { recursive: true })
+}
+
+async function initCacheMaps() {
+  cacheFile = path.join(cacheDir, 'contents')
+
+  try {
+    const json = JSON.parse(await readFile(cacheFile, 'utf-8'))
+    entryMap = new Map<string, CacheValue>(Object.entries(json))
+  } catch {
+    entryMap = new Map<string, CacheValue>()
+  }
+
+  fileCacheMap = new Map<string, CacheValue>(entryMap)
+}
+
+function md5(buffer: BinaryLike): string {
+  return crypto.createHash('md5').update(buffer).digest('hex')
+}
+
+async function getAndUpdateCacheContent(filePath: string | URL) {
+  try {
+    const hash = md5(await readFile(filePath))
+    const normalizedFilePath = filePath.toString()
+    const cacheValue = fileCacheMap.get(normalizedFilePath) as
+      | CacheValue
+      | undefined
+    if (cacheValue && cacheValue.hash === hash) {
+      return {
+        changed: false,
+      }
+    }
+    entryMap.set(normalizedFilePath, { hash })
+    return {
+      changed: true,
+    }
+  } catch (error) {
+    return {
+      changed: false,
+      error: error as Error,
+    }
+  }
+}
+
+export const FileCache = {
+  init: async (options: ResolvedConfigOptions, rootDir: string) => {
+    cacheEnabled = options.cache !== false
+
+    await initCacheDir(rootDir, options.cacheDir)
+
+    // clear cache?
+    if (options.clearCache && cacheDir) {
+      await rm(cacheDir.slice(0, -1), { recursive: true, force: true })
+    }
+
+    await initCacheMaps()
+  },
+
+  prepareDirs: (filePaths: string[]): void => {
+    if (cacheEnabled) {
+      smartEnsureDirs(filePaths.map(file => cacheDir + file))
+    }
+  },
+
+  check: async (
+    baseDir: string,
+    filePathFrom: string,
+    fileToStack: StackItem[] = [],
+  ) => {
+    const { changed, error } = await getAndUpdateCacheContent(
+      baseDir + filePathFrom,
+    )
+
+    // Check if input file has changed or there was an error
+    if (changed || error) {
+      return false
+    }
+
+    // Check if output files are in cache and use them if they haven't changed
+    const outputFilesExist = await Promise.allSettled(
+      fileToStack.map(
+        item =>
+          new Promise((resolve, reject) =>
+            getAndUpdateCacheContent(cacheDir + item.toPath)
+              .then(outputFileCache => {
+                if (!outputFileCache.error && !outputFileCache.changed) {
+                  copyFileSync(cacheDir + item.toPath, baseDir + item.toPath)
+                  if (existsSync(baseDir + item.toPath)) {
+                    resolve(true)
+                  }
+                }
+                reject(
+                  outputFileCache.error
+                    ? `Error while checking cache [${outputFileCache.error.message}]`
+                    : 'Could not copy cached files',
+                )
+              })
+              .catch(reject),
+          ),
+      ),
+    )
+
+    return outputFilesExist.every(p => p.status === 'fulfilled')
+  },
+
+  update: async (baseDir: string, filePathTo: string) => {
+    if (!cacheEnabled) {
+      return
+    }
+
+    await copyFile(baseDir + filePathTo, cacheDir + filePathTo)
+    await getAndUpdateCacheContent(cacheDir + filePathTo)
+  },
+
+  reconcile: async () => {
+    if (!cacheEnabled) {
+      return true
+    }
+
+    try {
+      await writeFile(
+        cacheFile,
+        JSON.stringify(Object.fromEntries(entryMap)),
+        'utf-8',
+      )
+      // reflect the changes in the cacheMap
+      fileCacheMap = new Map(entryMap)
+      return true
+    } catch (error) {
+      //   console.error('Cache reconcile has failed', error)
+      return false
+    }
+  },
+}

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -1368,7 +1368,7 @@ describe('logErrors', () => {
  *    dist/images/opaque-1.png.avif
  */
 
-// TODO: add tests for usage with cache
+// TODO: add tests for cache usage and its options
 // TODO: expand after-build checks
 
 describe.skipIf(skipBuilds)('viteImagemin', () => {

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -642,7 +642,7 @@ describe('processFile', () => {
     })
   })
 
-  it('returns error object if OUTPUT PROCESS error (Error & warn)', async () => {
+  it('returns error object if OUTPUT PROCESS error (Error & string)', async () => {
     await expect(
       // @ts-expect-error missing properties are used after expected error
       processFile({
@@ -655,9 +655,9 @@ describe('processFile', () => {
               //   optimization: 4,
               //   strip: 'safe',
               // }),
-              () => Promise.reject(new Error('Test')),
+              () => Promise.reject(new Error('Test error processing file')),
               // () => {
-              //   throw new Error('Test')
+              //   throw new Error('Test error processing file')
               // },
             ],
             skipIfLarger: false,
@@ -668,7 +668,9 @@ describe('processFile', () => {
     ).resolves.toContainEqual({
       status: 'rejected',
       reason: expect.objectContaining({
-        error: expect.stringMatching(/^Error processing file/),
+        error: expect.stringMatching(
+          /^Error processing file:\s+Test error processing file/,
+        ),
       }),
     })
 
@@ -684,9 +686,9 @@ describe('processFile', () => {
               //   optimization: 4,
               //   strip: 'safe',
               // }),
-              () => Promise.reject('WARN: Test error processing file'),
+              () => Promise.reject('Test error processing file'),
               // () => {
-              //   throw 'WARN: Test error processing file'
+              //   throw 'Test error processing file'
               // },
             ],
             skipIfLarger: false,
@@ -697,7 +699,9 @@ describe('processFile', () => {
     ).resolves.toContainEqual({
       status: 'rejected',
       reason: expect.objectContaining({
-        error: 'Test error processing file',
+        error: expect.stringMatching(
+          /^Error processing file:\s*Test error processing file/,
+        ),
       }),
     })
   })

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -216,7 +216,9 @@ export function formatProcessedFile({
     ratioString: `${ratio > 0 ? '+' : ratio === 0 ? ' ' : ''}${(
       ratio * 100
     ).toFixed(precisions.ratio)} %`,
-    durationString: `${duration.toFixed(precisions.duration)} ms`,
+    durationString: fromCache
+      ? 'Cache'
+      : `${duration.toFixed(precisions.duration)} ms`,
     fromCache,
     optimizedDeleted: false as const,
     avifDeleted: false as const,

--- a/packages/core/src/typings.d.ts
+++ b/packages/core/src/typings.d.ts
@@ -96,6 +96,12 @@ export interface ConfigOptions {
   cacheDir?: string
 
   /**
+   * Optional string to distinguish build configs and their caches.
+   * @default ''
+   */
+  cacheKey?: string
+
+  /**
    * Force-clear the cache.
    * @default false
    */
@@ -153,6 +159,7 @@ export interface ResolvedConfigOptions {
   cache: boolean
   cacheDir?: string
   clearCache: boolean
+  cacheKey: string
   plugins: ResolvedPluginsConfig
   makeAvif: false | ResolvedMakeConfigOptions
   makeWebp: false | ResolvedMakeConfigOptions
@@ -174,6 +181,22 @@ type StackItem = {
 
 export type Stack = {
   [fromPath: string]: StackItem[]
+}
+
+export type FormatProcessedFileParams = {
+  oldPath: string
+  newPath: string
+  oldSize: number
+  newSize: number
+  duration: number
+  fromCache: boolean
+  precisions: {
+    size: number
+    ratio: number
+    duration: number
+  }
+  bytesDivider: number
+  sizeUnit: string
 }
 
 export type ProcessFileParams = {
@@ -205,6 +228,7 @@ export type ProcessedFile = {
   optimizedDeleted: ResolvedMakeConfigOptions['skipIfLargerThan']
   avifDeleted: ResolvedMakeConfigOptions['skipIfLargerThan']
   webpDeleted: ResolvedMakeConfigOptions['skipIfLargerThan']
+  fromCache: boolean
 }
 
 export type ErroredFile = {
@@ -254,3 +278,9 @@ export type ProcessResult =
   | IPromiseRejectedResult<ErroredFile>
 
 export type ProcessFileReturn = Promise<ErroredFile | ProcessResultWhenOutput[]>
+
+export type CacheValue = {
+  hash: string
+  oldSize: number
+  newSize: number
+}

--- a/packages/core/src/typings.d.ts
+++ b/packages/core/src/typings.d.ts
@@ -87,6 +87,21 @@ export interface ConfigOptions {
   cache?: boolean
 
   /**
+   * Path of the directory to use for caching.
+   * Either:
+   *   - relative path to Vite's root
+   *   - absolute path
+   * @default <packageRoot>/node_modules/.cache/vite-plugin-imagemin
+   */
+  cacheDir?: string
+
+  /**
+   * Force-clear the cache.
+   * @default false
+   */
+  clearCache?: boolean
+
+  /**
    * Only use optimized contents if smaller than original.
    * @default true
    */
@@ -136,6 +151,8 @@ export interface ResolvedConfigOptions {
   verbose: boolean
   skipIfLarger: boolean
   cache: boolean
+  cacheDir?: string
+  clearCache: boolean
   plugins: ResolvedPluginsConfig
   makeAvif: false | ResolvedMakeConfigOptions
   makeWebp: false | ResolvedMakeConfigOptions

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -215,3 +215,4 @@ describe('smartEnsureDirs', () => {
 })
 
 // TODO: add tests for getPackageDirectory and getPackageName
+// TODO: create `cache.test.ts` with tests for cache functions

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -213,3 +213,5 @@ describe('smartEnsureDirs', () => {
     })
   })
 })
+
+// TODO: add tests for getPackageDirectory and getPackageName

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -52,6 +52,8 @@ export default defineConfig({
         // skipIfLargerThan: 'smallest',
       },
       // cache: false,
+      // clearCache: true,
+      // cacheDir: 'cache',
     }),
   ],
 })


### PR DESCRIPTION
- Adds option `clearCache` - Clears the cache before processing
- Adds option `cacheDir` - Choose the directory to use for caching
  - `cacheDir` by default is under the package's root folder in `node_modules/.cache/vite-plugin-imagemin/<packageName>`
  - Relative `cacheDir` path will be relative to Vite's `<root>` dir
  - Absolute `cacheDir` path will be just that

#### TODO
- [ ] Add tests for cache functionality and options